### PR TITLE
Исправление бага со структурными скобками и e-переменными.

### DIFF
--- a/lexer.js
+++ b/lexer.js
@@ -158,7 +158,7 @@ function *executeProgram() {
                 close_br = str.indexOf(">");
             }
             if (!matched){
-                result_array.push(`<span style='color: red'>Ошибка: скобки активации не соотвествуют ни одному из образцов.</span>`)
+                result_array.push(`<span style='color: red'>Ошибка: скобки активации не соответствуют ни одному из образцов.</span>`)
                 return result_array;
             }
             tokens_view[key] = str;

--- a/match.js
+++ b/match.js
@@ -1,9 +1,4 @@
 function match(expr, expr_pos, pattern, pattern_pos, vars){
-    // console.log("expr: ", expr);
-    // console.log("expr_pos: ", expr_pos);
-    // console.log("expr_pos: ", pattern);
-    // console.log("pattern_pos: ", pattern_pos);
-    // console.log("vars: ", vars);
     while (pattern_pos != pattern.length && (expr_pos != expr.length || pattern[pattern_pos][0] == "e" && !expr.slice(expr_pos).length)){
         if (pattern[pattern_pos].length == 1){
             if (expr[expr_pos] == pattern[pattern_pos]){
@@ -53,7 +48,18 @@ function match(expr, expr_pos, pattern, pattern_pos, vars){
             });
         } else {
             let end = expr_pos - 1;
-            while (end != expr.length && expr[expr_pos] != ")"){
+            while (end != expr.length){
+                let res = match(expr, end + 1, pattern, pattern_pos + 1, {
+                    [pattern[pattern_pos]]: expr.substr(expr_pos, end - expr_pos + 1),
+                    __proto__: vars
+                })
+                if (res.ok){
+                    return res;
+                }
+                end++;
+                if (end == expr.length && expr[expr_pos] == ")") {
+                    break;
+                }
                 if (expr[end] == "("){
                     let bracket_counter = 1;
                     while (bracket_counter > 0){
@@ -66,14 +72,6 @@ function match(expr, expr_pos, pattern, pattern_pos, vars){
                         }
                     }
                 }
-                let res = match(expr, end + 1, pattern, pattern_pos + 1, {
-                    [pattern[pattern_pos]]: expr.substr(expr_pos, end - expr_pos + 1),
-                    __proto__: vars
-                })
-                if (res.ok){
-                    return res;
-                }
-                end++;
             }
             return {ok: false};
         }


### PR DESCRIPTION
В текущей реализации Tiny Refal были обнаружены следующие ошибки:
- *баг*: неуспешное сопоставление шаблона e_x(e_y)e_z со строкой aa(bb)aa;
- опечатка в слове "соответствуют" в сообщении "скобки активации не соответствуют ни одному из образцов".
Причина бага: неправильный порядок действий в коде при сопоставлении с e-переменной.
Данный pull request исправляет указанные ошибки.